### PR TITLE
Updating Android Demo with the latest changes

### DIFF
--- a/DailyDemo/app/build.gradle
+++ b/DailyDemo/app/build.gradle
@@ -30,9 +30,8 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     // These paths disappear on clean. Always do ./gradlew :daily-android:assemble[variant] first
-    //debugImplementation files("${project.rootDir}/../../../daily-android/daily-android/build/outputs/aar/daily-android-debug.aar")
-    //releaseImplementation files("${project.rootDir}/../../../daily-android/daily-android/build/outputs/aar/daily-android-release.aar")
-    implementation 'co.daily:client:0.1.1'
+    //implementation files("libs/daily-android-release.aar")
+    implementation 'co.daily:client:0.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/DailyDemo/app/src/main/java/co/daily/core/dailydemo/MainActivity.kt
+++ b/DailyDemo/app/src/main/java/co/daily/core/dailydemo/MainActivity.kt
@@ -120,23 +120,18 @@ class MainActivity : AppCompatActivity() {
         // Render the next particpant in the list if any
         val nextParticipant =
             callClient.participants().all.values.firstOrNull{ !it.info.isLocal && it.media?.camera?.track != null }
-        if(nextParticipant != null){
-            updateRemoteVideoTrack(nextParticipant.media?.camera?.track)
-        } else {
-            clearRemoteVideoView()
-            updateRemoteCameraMaskViewMessage()
-        }
+        updateRemoteVideoTrack(nextParticipant?.media?.camera?.track)
     }
 
     private fun clearRemoteVideoView() {
-        remoteVideoView?.track = null
+        remoteVideoView?.release()
         remoteContainer?.removeView(remoteVideoView)
         remoteVideoView = null
         remoteCameraMaskView.visibility = View.VISIBLE
     }
 
     private fun clearLocalVideoView() {
-        localVideoView?.track = null
+        localVideoView?.release()
         localContainer?.removeView(localVideoView)
         localVideoView = null
         localCameraMaskView.visibility = View.VISIBLE
@@ -172,16 +167,15 @@ class MainActivity : AppCompatActivity() {
 
     private fun updateRemoteVideoTrack(track: MediaStreamTrack? = null) {
         Log.d(TAG, "updateRemoteVideoTrack ${track}")
-        if(track == null){
-            return
-        }
         if (remoteVideoView == null) {
             remoteVideoView = VideoView(this@MainActivity)
             remoteContainer?.addView(remoteVideoView)
-            remoteCameraMaskView.visibility = View.GONE
         }
-        // For now this will render whoever joins causing flickering
         remoteVideoView?.track = track
+        val containsTrack = track != null
+        remoteCameraMaskView.visibility = if(containsTrack) View.GONE else View.VISIBLE
+        remoteVideoView?.visibility = if(containsTrack) View.VISIBLE else View.GONE
+        updateRemoteCameraMaskViewMessage()
     }
 
     override fun onCreate(savedInstance: Bundle?) {

--- a/DailyDemo/app/src/main/res/layout/activity_main.xml
+++ b/DailyDemo/app/src/main/res/layout/activity_main.xml
@@ -132,13 +132,15 @@
 
             <EditText
                 android:id="@+id/aurl"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="match_parent"
+                android:layout_gravity="start"
                 android:layout_marginStart="10dp"
                 android:autofillHints=""
                 android:gravity="center"
                 android:hint="@string/tap_to_enter_room_url"
                 android:inputType="textUri"
+                android:maxWidth="280dp"
                 android:maxLines="1"
                 android:minWidth="280dp"
                 android:textColorHint="#546E7A"
@@ -147,6 +149,7 @@
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
+                android:layout_gravity="end"
                 android:layout_marginEnd="10dp"
                 android:minWidth="90dp">
 


### PR DESCRIPTION
Updating Android Demo with the latest changes:
- Improving the way we are handling the tracks on VideoView;
- Invoking to release the resource of VideoView on exit;
- Fixing the issue if we enter an URL too long, then rotate to landscape mode and then back to portrait, the join/leave button disappears.

Important: before merge this, we need to update build.gradle with the latest change of the Android library, which contains the `release` method on `VideoView`