### PR TITLE
nit: change enabled and accent colors

### DIFF
--- a/DailyDemo/app/src/main/res/values/colors.xml
+++ b/DailyDemo/app/src/main/res/values/colors.xml
@@ -2,8 +2,8 @@
 <resources>
     <color name="colorPrimary">#EEEFF4</color>
     <color name="colorPrimaryDark">#525255</color>
-    <color name="colorAccent">#C54949</color>
-    <color name="colorEnabled">#C54949</color>
+    <color name="colorAccent">#62A60F</color>
+    <color name="colorEnabled">#00C9DF</color>
     <color name="colorDisabled">#C0C0C3</color>
     <color name="colorToast">#C5B69B</color>
 </resources>


### PR DESCRIPTION
Red as an "enabled" color can be a little confusing from a UX perspective.